### PR TITLE
Migrate image decoding to typst 0.13

### DIFF
--- a/note-me.typ
+++ b/note-me.typ
@@ -17,7 +17,7 @@
   ..args,
 ) = {
   let data = colorize(read(path), color)
-  return image(bytes(data, ..args))
+  return image(bytes(data), ..args)
 }
 
 // Returns a new SVG image loaded from the specified string (SVG content), filled with the specified color.
@@ -27,7 +27,7 @@
   ..args,
 ) = {
   let data = colorize(svg, color)
-  return image(bytes(data, ..args))
+  return image(bytes(data), ..args)
 }
 
 #let admonition(
@@ -57,7 +57,7 @@
             message: "Either `icon-path`, `icon-string` or `icon` must be specified in the argument."
           )
           if (icon-path != none) {
-             color-svg-path(icon-path, color, width: 1em, height: 1em)
+            color-svg-path(icon-path, color, width: 1em, height: 1em)
           } 
           if (icon-string != none) {
             color-svg-string(icon-string, color, width: 1em, height: 1em)

--- a/note-me.typ
+++ b/note-me.typ
@@ -17,7 +17,7 @@
   ..args,
 ) = {
   let data = colorize(read(path), color)
-  return image.decode(data, ..args)
+  return image(bytes(data, ..args))
 }
 
 // Returns a new SVG image loaded from the specified string (SVG content), filled with the specified color.
@@ -27,7 +27,7 @@
   ..args,
 ) = {
   let data = colorize(svg, color)
-  return image.decode(data, ..args)
+  return image(bytes(data, ..args))
 }
 
 #let admonition(


### PR DESCRIPTION
Hi @FlandiaYingman 👋 
Thanks a lot for `note-me`, love it! That's a great package I always import in my typst documents

Here is a little PR to migrate `note-me` to typst 0.13 and shut a warning on the deprecated `image.decode(..)` method.
See [typst 0.13 changelog](https://typst.app/blog/2025/typst-0.13)

> [!WARNING]  
> Sorry I didn't test the change though 😅 , might worth a little test before merging