### PR TITLE
Accessible icons for admonitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ Import this package, and write
 
 #admonition(
   icon-path: "icons/stop.svg",
+  // `auto` (dfault), `str` with an alt text that will be added for the icon,
+  // or `none` to mark the icon as purely decorative not needing an alt text.
+  icon-alt: "Stop sign",
   color: color.fuchsia,
   title: "Customize",
   foreground-color: color.white,
   background-color: color.black,
 )[
-  The icon, (theme) color, title, foreground and background color are customizable.
+  The icon, icon alt text, (theme) color, title, foreground and background color are customizable.
 ]
 
 #admonition(

--- a/note-me-more.typ
+++ b/note-me-more.typ
@@ -2,6 +2,7 @@
 
 #let todo(title: "TODO", children) = admonition(
   icon-path: "icons/question.svg",
+  icon-alt: none,
   title: title,
   color: rgb(209, 36, 47),
   children

--- a/note-me.typ
+++ b/note-me.typ
@@ -1,4 +1,5 @@
 #import "stick-together.typ": stick-together
+#import "utils.typ"
 
 // From: https://github.com/typst/typst/issues/1939#issuecomment-1680154871
 #let colorize(svg, color) = {
@@ -13,27 +14,30 @@
 // Returns a new SVG image loaded from the specified path, filled with the specified color.
 #let color-svg-path(
   path,
-  color, 
+  color,
+  alt: auto,
   ..args,
 ) = {
   let data = colorize(read(path), color)
-  return image(bytes(data), ..args)
+  return utils.accessible-icon(data, alt, ..args)
 }
 
 // Returns a new SVG image loaded from the specified string (SVG content), filled with the specified color.
 #let color-svg-string(
   svg,
-  color, 
+  color,
+  alt: auto,
   ..args,
 ) = {
   let data = colorize(svg, color)
-  return image(bytes(data), ..args)
+  return utils.accessible-icon(data, alt, ..args)
 }
 
 #let admonition(
   icon-path: none,
   icon-string: none,
   icon: none,
+  icon-alt: auto,
   title: "Admonition",
   color: color.black,
   foreground-color: auto,
@@ -57,10 +61,10 @@
             message: "Either `icon-path`, `icon-string` or `icon` must be specified in the argument."
           )
           if (icon-path != none) {
-            color-svg-path(icon-path, color, width: 1em, height: 1em)
+            color-svg-path(icon-path, color, alt: icon-alt, width: 1em, height: 1em)
           } 
           if (icon-string != none) {
-            color-svg-string(icon-string, color, width: 1em, height: 1em)
+            color-svg-string(icon-string, color, alt: icon-alt, width: 1em, height: 1em)
           }
           if (icon != none) {
             icon
@@ -82,30 +86,35 @@
 
 #let note(title: "Note", children) = admonition(
   icon-path: "icons/info.svg",
+  icon-alt: none,
   title: title,
   color: rgb(9, 105, 218),
   children
 )
 #let tip(title: "Tip", children) = admonition(
   icon-path: "icons/light-bulb.svg",
+  icon-alt: none,
   title: title,
   color: rgb(31, 136, 61),
   children
 )
 #let important(title: "Important", children) = admonition(
   icon-path: "icons/report.svg",
+  icon-alt: none,
   title: title,
   color: rgb(130, 80, 223),
   children
 )
 #let warning(title: "Warning", children) = admonition(
   icon-path: "icons/alert.svg",
+  icon-alt: none,
   title: title,
   color: rgb(154, 103, 0),
   children
 )
 #let caution(title: "Caution", children) = admonition(
   icon-path: "icons/stop.svg",
+  icon-alt: none,
   title: title,
   color: rgb(209, 36, 47),
   children

--- a/utils.typ
+++ b/utils.typ
@@ -1,0 +1,14 @@
+#let accessible-icon(
+  data,
+  alt: auto,
+  ..args,
+) = {
+  if alt == auto {
+    image(bytes(data), ..args)
+  } else if alt == none {
+    pdf.artifact(image(bytes(data), ..args))
+  } else {
+    assert.eq(type(alt), str, "`alt` must be either of `auto`, `str` or `none`")
+    image(bytes(data), alt: alt, ..args)
+  }
+}


### PR DESCRIPTION
This was supposed to be an issue at first, but I just ended up coding up my proposed solution as I wrote it... 😅

# Issue

When compiling with `--pdf-standard ua-1` it fails with an error message:

<img width="629" height="206" alt="Image" src="https://github.com/user-attachments/assets/bc1e41ac-c3f8-454f-80ea-36ef0b560536" />

PDF/UA produces universal access compatible files by checking certain accessibility requirements. It would be nice to make this pass with note-me.

This basically would require changing how the icons are added in this section of the `admonition` function:

```
if (icon-path != none) {
  color-svg-path(icon-path, color, width: 1em, height: 1em)
} 
if (icon-string != none) {
  color-svg-string(icon-string, color, width: 1em, height: 1em)
}
if (icon != none) {
  icon
}
```

One would either need to be able to provide an `alt` attribute with alt text for the image, or (which I believe is the more likely one for 99% of usages) when the icon is simply a decorative addition to the title it should be wrapped in a `pdf.artifact` ([see here](https://typst.app/docs/reference/pdf/artifact/)).

# Different ways to use it

Now there are different ways to create the admonition already:

1. Use one of the default admonitions (`note`, etc.): There's no way to provide `alt` text or wrap the icon in an `artifact`.
2. Passing your own `icon`: The user already has full control and can decide to set an `alt` attribute or wrap it in an `artifact`.
3. Passing `icon-path` or `icon-string`: There's no way to wrap it in an `artifact` or provide an `alt` text.

# Workarounds

For case 3: One can use their own `icon-string` or use one of the predefined icons through `icon-path` by manually calling `color-svg-path` or `color-svg-string` which takes arbitrary arguments and passes them on to the image constructor. That way the user can either pass an `alt` text, or alternatively they can also wrap the result in an `artifact` before passing it on as `icon` argument to the admonition.

But this workaround is kind of unhandy though if you want to use one of the provided icons of the package or just provide a svg-string.

# Proposed solution

I propose multiple steps to improve the situation:

1. Add a `accessible-icon` utility function that takes the arguments `data`, `alt` and `..args` attributes with the possible options of `auto` (default), `string`, or `none` for `alt`:
    - `auto` would do nothing for accessibility, possibly causing an error for the user if he just forgot to add one and is compiling with accessibility checks.
    - `string` would be the alt text that gets added to the image
    - `none` would explicitly opt out of an alt text and wrap the image in a `artifact`.
2. Add an `alt` attribute to `color-svg-path` and `color-svg-string`, this will be passed on to `accessible-icon` to create an image with the accessibility set as defined above.
3. Add an `icon-alt` to admonition that will be used for `color-svg-path` and `color-svg-string`.
4. Make the predefined admonitions all use `icon-alt: none` since they all appear purely decorative to me.